### PR TITLE
Fix typo in diagnostic message

### DIFF
--- a/Src/convenience.cpp
+++ b/Src/convenience.cpp
@@ -2966,7 +2966,7 @@ bool check_OpenBLAS_DLL(const bool &debug)
     else
     {
         if (debug)
-            std::cout << "DLL does not exist, extracting it form teh executable!" << std::endl;
+            std::cout << "DLL does not exist, extracting it from the executable!" << std::endl;
         // Extract the DLL if it does not exist
         if (!ExtractDLL(dllName))
         {


### PR DESCRIPTION
## Summary
- correct a typo in the convenience DLL diagnostic message

## Testing
- `make test` *(fails: can't cd to featomic)*

------
https://chatgpt.com/codex/tasks/task_e_684c8781256c8328be69109a410a1eed